### PR TITLE
Correct monitored service name: IISADMIN -> W3SVC

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-iis/milestones?state=closed).
 
+## 1.1.0 (2025-09-02)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-iis/milestone/2)
+
+### Bugfixes
+
+* [#3](https://github.com/Icinga/icinga-powershell-iis/pull/3) Fixes detection if IIS installed by using `W3SVC` as service name instead
+
 ## 1.0.0 (2025-01-31)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-iis/milestone/1)

--- a/provider/public/New-IcingaProviderFilterDataIIS.psm1
+++ b/provider/public/New-IcingaProviderFilterDataIIS.psm1
@@ -12,7 +12,7 @@ function New-IcingaProviderFilterDataIIS()
     );
 
     $IISData         = New-IcingaProviderObject                 -Name 'IIS';
-    $IISService      = Get-Service -Name 'IISADMIN'             -ErrorAction SilentlyContinue;
+    $IISService      = Get-Service -Name 'W3SVC'                -ErrorAction SilentlyContinue;
     $IISToolsPresent = Get-Command -Name 'Get-IISConfigSection' -ErrorAction SilentlyContinue;
 
     $IISData.Metadata | Add-Member -MemberType NoteProperty -Name 'IISHost'   -Value (Get-IcingaHostname);


### PR DESCRIPTION
fixes #2
fixes #3

ref/IP/58070

## How to install this ...

### ... for testing

1. Open PowerShell as admin
    1. Install IIS: `Enable-WindowsOptionalFeature -FeatureName IIS-WebServerRole -Online`
    2. Prepare IfW install: `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass`
    3. Install IfW framework: https://icinga.com/docs/icinga-for-windows/latest/doc/110-Installation/01-Getting-Started/#install-icinga-for-windows
        * "Where do you want to install ...": enter
        * "... run the Icinga Management Console?": y
            * Settings/ Repositories/ Icinga Stable/ Continue/ Exit
        * Install dependency: `Install-IcingaComponent -Name plugins`
2. Continue with the following section

### ... in production

1. Create a folder as you wish, say, `C:\iispatch`
2. Download this PR there: https://github.com/Al2Klimov/icinga-powershell-iis/archive/refs/heads/patch-1.zip
3. Open PowerShell as admin
    * Create local repo: `New-IcingaRepository -Name iispatch -Path C:\iispatch -Snapshot`
    * Install this PR from it: `Install-IcingaComponent -Name iis -Snapshot`

Now `C:\Program Files\WindowsPowerShell\Modules\icinga-powershell-iis\provider/public/New-IcingaProviderFilterDataIIS.psm1` must look as in _files changed_ here!

## Test

Tested on WS25, WS16 and 2012r2.

With this PR, Invoke-IcingaCheckIISHealth may complain with "[UNKNOWN] IIS Service: The IIS tools are not installed" (on 2012r2 or even crash on newer ones). At least this is a different error message than #2. And it can be fixed like this:

`Enable-WindowsOptionalFeature -FeatureName IIS-ManagementScriptingTools -Online`

### WS16+

```
PS C:\Users\Administrator> Invoke-IcingaCheckIISHealth
[OK] IIS Health: 1 Ok
| akws16::ifw_iishealth::iishealth=4;;4;;
0
PS C:\Users\Administrator>
```

### 2012r2

```
PS C:\Program Files\WindowsPowerShell\Modules> Invoke-IcingaCheckIISHealth
[UNKNOWN] IIS Health: 1 Unknown [UNKNOWN] IIS Service
\_ [UNKNOWN] IIS Service: The IIS tools are not installed
3
PS C:\Program Files\WindowsPowerShell\Modules>
```

# 🤷‍♂️

#### Friendly reminder

> Extended support for [Windows Server 2012](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012) and [Windows Server 2012 R2](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012-r2) will be ending on October 10, 2023.

– https://learn.microsoft.com/en-us/windows-server/get-started/extended-security-updates-overview

## My recommendations

### @Wintermute2k6

Until the next release, as a bridge technology, install this PR as above. Or wait for it to be merged and use our snapshot repo.

### @bobapple

Merge this, so that customers can directly use our snapshot repo instead of a custom one created from the @Al2Klimov namespace. The diff is dead simple and _it works on my machine_<sup>TM</sup>.