### PR TITLE
Fix: Removes WMI dependency for root/Webadministrator

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#3](https://github.com/Icinga/icinga-powershell-iis/pull/3) Fixes detection if IIS installed by using `W3SVC` as service name instead
+* [#5](https://github.com/Icinga/icinga-powershell-iis/pull/5) Fixes the App Pool health check by removing the WMI dependency for `root/Webadministrator` to ensure IIS-Tools are not required
 
 ## 1.0.0 (2025-01-31)
 

--- a/plugins/Invoke-IcingaCheckIISAppPoolHealth.psm1
+++ b/plugins/Invoke-IcingaCheckIISAppPoolHealth.psm1
@@ -7,7 +7,6 @@
 .ROLE
     ### WMI Permissions
 
-    * Root\WebAdministration
     * Win32_PerfFormattedData_PerfProc_Process
 .PARAMETER CPUWarning
     The CPU usage percentage that triggers a warning state.


### PR DESCRIPTION
Fixes the App Pool health check by removing the WMI dependency for `root/Webadministrator` to ensure IIS-Tools are not required